### PR TITLE
Add Wagtail 2 & Django 2 support

### DIFF
--- a/wagtailtinymce/rich_text.py
+++ b/wagtailtinymce/rich_text.py
@@ -32,9 +32,9 @@ from django.forms import widgets
 from django.utils import translation
 from wagtail.utils.widgets import WidgetWithScript
 
-from wagtail import __version__
+from wagtail import __version__ as WAGTAIL_VERSION
 
-if __version__ >= '2.0':
+if WAGTAIL_VERSION >= '2.0':
     from wagtail.admin.edit_handlers import RichTextFieldPanel
     from wagtail.admin.rich_text.converters.editor_html import EditorHTMLConverter
     from wagtail.core.rich_text import features
@@ -88,7 +88,7 @@ class TinyMCERichTextArea(WidgetWithScript, widgets.Textarea):
         super(TinyMCERichTextArea, self).__init__(attrs)
         self.features = kwargs.pop('features', None)
 
-        if __version__ >= '2.0':
+        if WAGTAIL_VERSION >= '2.0':
             if self.features is None:
                 self.features = features.get_default_features()
                 self.converter = EditorHTMLConverter()
@@ -109,7 +109,7 @@ class TinyMCERichTextArea(WidgetWithScript, widgets.Textarea):
         if value is None:
             translated_value = None
         else:
-            if __version__ >= '2.0':
+            if WAGTAIL_VERSION >= '2.0':
                 translated_value = self.converter.from_database_format(value)
             else:
                 translated_value = expand_db_html(value, for_editor=True)
@@ -153,7 +153,7 @@ class TinyMCERichTextArea(WidgetWithScript, widgets.Textarea):
         if original_value is None:
             return None
 
-        if __version__ >= '2.0':
+        if WAGTAIL_VERSION >= '2.0':
             return self.converter.to_database_format(original_value)
         else:
             return DbWhitelister.clean(original_value)

--- a/wagtailtinymce/rich_text.py
+++ b/wagtailtinymce/rich_text.py
@@ -31,9 +31,17 @@ from copy import deepcopy
 from django.forms import widgets
 from django.utils import translation
 from wagtail.utils.widgets import WidgetWithScript
-from wagtail.wagtailadmin.edit_handlers import RichTextFieldPanel
-from wagtail.wagtailcore.rich_text import DbWhitelister
-from wagtail.wagtailcore.rich_text import expand_db_html
+
+from wagtail import __version__
+
+if __version__ >= '2.0':
+    from wagtail.admin.edit_handlers import RichTextFieldPanel
+    from wagtail.admin.rich_text.converters.editor_html import DbWhitelister
+    from wagtail.core.rich_text import expand_db_html
+else:
+    from wagtail.wagtailadmin.edit_handlers import RichTextFieldPanel
+    from wagtail.wagtailcore.rich_text import DbWhitelister
+    from wagtail.wagtailcore.rich_text import expand_db_html
 
 DEFAULT_BUTTONS = [
     [

--- a/wagtailtinymce/rich_text.py
+++ b/wagtailtinymce/rich_text.py
@@ -36,8 +36,8 @@ from wagtail import __version__
 
 if __version__ >= '2.0':
     from wagtail.admin.edit_handlers import RichTextFieldPanel
-    from wagtail.admin.rich_text.converters.editor_html import DbWhitelister
-    from wagtail.core.rich_text import expand_db_html
+    from wagtail.admin.rich_text.converters.editor_html import EditorHTMLConverter
+    from wagtail.core.rich_text import features
 else:
     from wagtail.wagtailadmin.edit_handlers import RichTextFieldPanel
     from wagtail.wagtailcore.rich_text import DbWhitelister
@@ -70,7 +70,7 @@ class TinyMCERichTextArea(WidgetWithScript, widgets.Textarea):
     default_buttons = DEFAULT_BUTTONS
     default_options = DEFAULT_OPTIONS
 
-    def __init__(self, attrs=None, buttons=None, menus=False, options=None):
+    def __init__(self, attrs=None, buttons=None, menus=False, options=None, **kwargs):
         """
 
         :param attrs: HTML field attributes
@@ -86,6 +86,15 @@ class TinyMCERichTextArea(WidgetWithScript, widgets.Textarea):
         :type options: dict[str, object]
         """
         super(TinyMCERichTextArea, self).__init__(attrs)
+        self.features = kwargs.pop('features', None)
+
+        if __version__ >= '2.0':
+            if self.features is None:
+                self.features = features.get_default_features()
+                self.converter = EditorHTMLConverter()
+            else:
+                self.converter = EditorHTMLConverter(self.features)
+
         if buttons is None:
             buttons = deepcopy(self.default_buttons)
         self.tinymce_buttons = buttons
@@ -100,7 +109,10 @@ class TinyMCERichTextArea(WidgetWithScript, widgets.Textarea):
         if value is None:
             translated_value = None
         else:
-            translated_value = expand_db_html(value, for_editor=True)
+            if __version__ >= '2.0':
+                translated_value = self.converter.from_database_format(value)
+            else:
+                translated_value = expand_db_html(value, for_editor=True)
         return super(TinyMCERichTextArea, self).render(name, translated_value, attrs)
 
     def render_js_init(self, id_, name, value):
@@ -140,4 +152,8 @@ class TinyMCERichTextArea(WidgetWithScript, widgets.Textarea):
         original_value = super(TinyMCERichTextArea, self).value_from_datadict(data, files, name)
         if original_value is None:
             return None
-        return DbWhitelister.clean(original_value)
+
+        if __version__ >= '2.0':
+            return self.converter.to_database_format(original_value)
+        else:
+            return DbWhitelister.clean(original_value)

--- a/wagtailtinymce/wagtail_hooks.py
+++ b/wagtailtinymce/wagtail_hooks.py
@@ -26,7 +26,7 @@
 
 import json
 
-from django.core.urlresolvers import reverse
+from django import __version__ as DJANGO_VERSION
 from django.templatetags.static import static
 from django.utils import translation
 from django.utils.html import escape
@@ -34,9 +34,14 @@ from django.utils.html import format_html
 from django.utils.html import format_html_join
 from django.utils.safestring import mark_safe
 
-from wagtail import __version__
+from wagtail import __version__ as WAGTAIL_VERSION
 
-if __version__ >= '2.0':
+if DJANGO_VERSION >= '2.0':
+    from django.urls import reverse
+else:
+    from django.core.urlresolvers import reverse
+
+if WAGTAIL_VERSION >= '2.0':
     from wagtail.admin.templatetags.wagtailadmin_tags import hook_output
     from wagtail.core import hooks
 else:

--- a/wagtailtinymce/wagtail_hooks.py
+++ b/wagtailtinymce/wagtail_hooks.py
@@ -34,8 +34,14 @@ from django.utils.html import format_html
 from django.utils.html import format_html_join
 from django.utils.safestring import mark_safe
 
-from wagtail.wagtailadmin.templatetags.wagtailadmin_tags import hook_output
-from wagtail.wagtailcore import hooks
+from wagtail import __version__
+
+if __version__ >= '2.0':
+    from wagtail.admin.templatetags.wagtailadmin_tags import hook_output
+    from wagtail.core import hooks
+else:
+    from wagtail.wagtailadmin.templatetags.wagtailadmin_tags import hook_output
+    from wagtail.wagtailcore import hooks
 
 
 def to_js_primitive(string):


### PR DESCRIPTION
This PR adds support Wagtail 2 & Django 2 support to WagtailTinyMCE.  The main repository of Wagtail TinyMCE haven't merged these supports to main repository so this has been added to fork repository. Credits goes to @k0nG as he has done a good job in the PR https://github.com/isotoma/wagtailtinymce/pull/23

The `extensibility` branch has been used in the [Digihel](https://github.com/city-of-helsinki/digihel) project were we currently working with the Wagtail 2 upgrade.