### PR TITLE
Fix Django 2.1 and later version compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ install_requires = [
 
 setup(
     name='wagtailtinymce',
-    version='4.4.3.0',
+    version='4.4.3.1',
     description='A TinyMCE editor integration for Wagtail',
     author='Richard Mitchell',
     author_email='richard.mitchell@isotoma.com',

--- a/wagtailtinymce/rich_text.py
+++ b/wagtailtinymce/rich_text.py
@@ -105,7 +105,7 @@ class TinyMCERichTextArea(WidgetWithScript, widgets.Textarea):
     def get_panel(self):
         return RichTextFieldPanel
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         if value is None:
             translated_value = None
         else:
@@ -113,7 +113,7 @@ class TinyMCERichTextArea(WidgetWithScript, widgets.Textarea):
                 translated_value = self.converter.from_database_format(value)
             else:
                 translated_value = expand_db_html(value, for_editor=True)
-        return super(TinyMCERichTextArea, self).render(name, translated_value, attrs)
+        return super(TinyMCERichTextArea, self).render(name, translated_value, attrs, renderer)
 
     def render_js_init(self, id_, name, value):
         return "{0}({1}, {2});".format(


### PR DESCRIPTION
Support for Widget.render() methods without the renderer argument is removed.
https://docs.djangoproject.com/en/2.1/releases/2.1/#features-removed-in-2-1